### PR TITLE
Fix hallucination segfault panic

### DIFF
--- a/src/objnam.c
+++ b/src/objnam.c
@@ -570,6 +570,10 @@ register struct obj *obj;
 		hobj->quan = obj->quan;
 		/* WAC clean up */
 		buf = xname2(hobj);
+		
+		if (Has_contents(hobj))
+			delete_contents(hobj);
+		
 		obj_extract_self(hobj);                
 		dealloc_obj(hobj);
 


### PR DESCRIPTION
Long-standing bug from SLASH'EM. It would randomly trigger when the hallucination made a dummy tool for the hallucinated appearance, since those tools can be containers that contain eggs or other timered objects, which weren't being cleaned up properly.