### PR TITLE
Bugfix: cancelling monsters called `attrcurse()` on player

### DIFF
--- a/src/zap.c
+++ b/src/zap.c
@@ -2990,9 +2990,10 @@ boolean			youattack, allow_cancel_kill, self_cancel;
 		find_ac();
 	    }
 	    /* Indicate to the hero that something happened */
-	    if (did_cancel && !self_cancel && youdefend)
+	    if (did_cancel && !self_cancel && youdefend) {
 		You_feel("a strange sense of loss.");
-	    attrcurse(); /* remove some random intrinsic as well --Amy */
+	    	attrcurse(); /* remove some random intrinsic as well --Amy */
+	    }    
 	}
 
 	/* now handle special cases */


### PR DESCRIPTION
Would quickly strip away all intrinsics from a player wielding Magicbane >_>