### PR TITLE
Make blacksmith remember orders across saves

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -2127,6 +2127,8 @@ E void NDECL(attrcurse);
 /* ### smith.c ### */
 
 E void FDECL(smith_selling, (struct monst *));
+E void FDECL(savesmithstate, (register int, register int));
+E void FDECL(restsmithstate, (int));
 
 /* ### sounds.c ### */
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -462,6 +462,7 @@ unsigned int *stuckid, *steedid;	/* STEED */
 	mread(fd, (genericptr_t) pl_fruit, sizeof pl_fruit);
 	mread(fd, (genericptr_t) &current_fruit, sizeof current_fruit);
 	mread(fd, (genericptr_t) &alchemy_table, sizeof (alchemy_table));
+	restsmithstate(fd);
 	freefruitchn(ffruit);	/* clean up fruit(s) made by initoptions() */
 	ffruit = loadfruitchn(fd);
 

--- a/src/save.c
+++ b/src/save.c
@@ -392,6 +392,7 @@ register int fd, mode;
 	bwrite(fd, (genericptr_t) pl_fruit, sizeof pl_fruit);
 	bwrite(fd, (genericptr_t) &current_fruit, sizeof current_fruit);
 	bwrite(fd, (genericptr_t) &alchemy_table, sizeof(alchemy_table));
+	savesmithstate(fd, mode);
 	savefruitchn(fd, mode);
 	savenames(fd, mode);
 	save_artifacts(fd);

--- a/src/smith.c
+++ b/src/smith.c
@@ -3,6 +3,7 @@
 /* Copyright 1994, Sebastian Klein */
 
 #include "hack.h"
+#include "lev.h"
 #include <stdio.h>
 #include <ctype.h>
 
@@ -363,6 +364,30 @@ void smith_selling(struct monst *smith)
 	} else {
 		verbalize("I'm working. Please don't disturb me again!");
 		time_finished += 5;	/* he was interrupted */
+	}
+}
+
+/* used in save.c */
+void savesmithstate(register int fd, register int mode) {
+	if (!perform_bwrite(mode))
+		return;
+	bwrite(fd, (genericptr_t) &time_finished, sizeof (int));
+	if (time_finished != -1) {
+		unsigned int xl;
+		xl = weapon->oxlth + weapon->onamelth;
+		bwrite(fd, (genericptr_t) &xl, sizeof(unsigned int));
+		bwrite(fd, (genericptr_t) weapon, xl + sizeof(struct obj));
+	}
+}
+
+/* used in restore.c */
+void restsmithstate(int fd) {
+	mread(fd, (genericptr_t) &time_finished, sizeof(int));
+	if (time_finished != -1) {
+		unsigned int xl;
+		mread(fd, (genericptr_t) &xl, sizeof (unsigned int));
+		weapon = newobj(xl);
+		mread(fd, (genericptr_t) weapon, xl + sizeof (struct obj));
 	}
 }
 


### PR DESCRIPTION
This saves the time_remaining and weapon objects across saves, so the
blacksmith doesn't scam you.

This loosely follows how objects are saved and loaded in {save,rest}objchn

Public servers should bump the EDITLEVEL as this breaks current saves

Relates to #44 