### PR TITLE
Fix segfault when raising human zombies

### DIFF
--- a/src/tech.c
+++ b/src/tech.c
@@ -1341,7 +1341,11 @@ int tech_no;
 			    if (mtmp) {
 				if (!resist(mtmp, SPBOOK_CLASS, 0, TELL)) {
 				   mtmp = tamedog(mtmp, (struct obj *) 0);
-				   You("dominate %s!", mon_nam(mtmp));
+				   if (mtmp) {
+				       You("dominate %s!", mon_nam(mtmp));
+				   } else {
+				       You("fail to dominate the reviving corpse.");
+				   }
 				} else setmangry(mtmp);
 			    }
 			}


### PR DESCRIPTION
Humans can't be tamed at all, so tamedog returned null for them.
Attempting to read the monster name of a null monster then caused a
segfault.

Fixes #29 