### PR TITLE
Fix geek and hacker quests

### DIFF
--- a/dat/Geek.des
+++ b/dat/Geek.des
@@ -4,7 +4,7 @@
 
 # --- start level ---
 
-MAZE: "Gra-strt",' '
+MAZE: "Gee-strt",' '
 FLAGS: noteleport,hardfloor
 GEOMETRY: center,center
 
@@ -131,7 +131,7 @@ TRAP:random,random
 
 # looks harmless but *IS* tough!!!
 
-MAZE: "Gra-loca",' '
+MAZE: "Gee-loca",' '
 FLAGS: hardfloor
 GEOMETRY: center,center
 
@@ -222,7 +222,7 @@ TRAP:random,random
 
 # --- the goal level ---
 
-MAZE: "Gra-goal", ' '
+MAZE: "Gee-goal", ' '
 GEOMETRY:center,center
 
 #         1         2         3         4         5         6         7
@@ -327,7 +327,7 @@ TRAP:random,random
 
 # --- fill a ---
 
-LEVEL: "Gra-fila"
+LEVEL: "Gee-fila"
 
 ROOM: "ordinary", random, random, random, random
 STAIR: random,up
@@ -372,7 +372,7 @@ RANDOM_CORRIDORS
 
 # --- fill b ---
 
-LEVEL: "Gra-filb"
+LEVEL: "Gee-filb"
 
 ROOM: "ordinary", random, random, random, random
 STAIR: random,up

--- a/dat/Hacker.des
+++ b/dat/Hacker.des
@@ -4,7 +4,7 @@
 
 # --- start level ---
 
-MAZE: "Gee-strt",' '
+MAZE: "Hac-strt",' '
 FLAGS: noteleport,hardfloor
 GEOMETRY: center,center
 
@@ -120,7 +120,7 @@ TRAP:random,random
 
 # looks harmless but *IS* tough!!!
 
-MAZE: "Gee-loca",' '
+MAZE: "Hac-loca",' '
 FLAGS: hardfloor
 GEOMETRY: center,center
 
@@ -201,7 +201,7 @@ TRAP:random,random
 
 # --- the goal level ---
 
-MAZE: "Gee-goal", ' '
+MAZE: "Hac-goal", ' '
 GEOMETRY:center,center
 
 #         1         2         3         4         5         6         7
@@ -265,7 +265,7 @@ OBJECT:random,random,random
 
 # --- fill a ---
 
-LEVEL: "Gee-fila"
+LEVEL: "Hac-fila"
 
 ROOM: "ordinary", random, random, random, random
 STAIR: random,up
@@ -310,7 +310,7 @@ RANDOM_CORRIDORS
 
 # --- fill b ---
 
-LEVEL: "Gee-filb"
+LEVEL: "Hac-filb"
 
 ROOM: "ordinary", random, random, random, random
 STAIR: random,up


### PR DESCRIPTION
When these roles were renamed, the names of the levels within their
respective des files weren't updated correctly

This means that loading the quests as either of these roles will
entirely fail, making the game unwinnable

Fixes #82 