### PR TITLE
Fix panic at bohsplosion

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -3055,7 +3055,10 @@ BOOLEAN_P destroy_after;
 
 		if (otmp->otyp == GOLD_PIECE) {
 #ifndef GOLDOBJ
-			dealloc_obj(otmp);
+			/* It feels like we don't really need this, */
+			/* the object has just been placed on the ground */
+			/* rather than being taken into the inventory */
+			/* dealloc_obj(otmp); */
 #endif
 			bot();	/* update character's gold piece count immediately */
 		}


### PR DESCRIPTION
If the boh had gold in, it would try to deallocate the gold object,
but the gold object was on the floor and not really free, firing a panic

The offending line of code appears to be from slex, and a version
shortly after slashthem's release comments it out - this seems to
be a sensible solution, to just not do it at all