### PR TITLE
Fix a few issues with gold bug attacks

### DIFF
--- a/src/mhitm.c
+++ b/src/mhitm.c
@@ -1907,7 +1907,7 @@ physical:
 			if (geatme->quan < metab_time) metab_time = geatme->quan; 
 			magr->mspec_used += metab_time/2 + 1;  /* instead of meating */
 		    }
-		    if (meatmetal_effects(magr, geatme) == 3) return MM_AGR_DIED;
+		    if (meatmetal_effects(magr, geatme) == 2) return MM_AGR_DIED;
 		    newsym(mdef->mx, mdef->my);
 		    if(cansee(mdef->mx, mdef->my)){
 			if (canseemon(mdef))
@@ -1952,7 +1952,7 @@ physical:
 		    pline("%s %s %s%s!",
 		      Monnam(magr), (how)?"gobbles":"nabs", yname(geatme), buf);
 		    if (how){
-			if (meatmetal_effects(magr, geatme) == 3) return MM_AGR_DIED;
+			if (meatmetal_effects(magr, geatme) == 2) return MM_AGR_DIED;
 		    } else
 			mpickobj(magr, geatme);
 

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -1975,7 +1975,7 @@ drain_life:
 			    pline("%s quickly %s some gold from %s your %s!",
 			      Monnam(mtmp), (mtmp->mcan)?"nabs":"gnoshes on", 
 			      (Levitation)?"beneath":"between", makeplural(body_part(FOOT)));
-			if (meatmetal_effects(mtmp, geatme) == 3) return 2;
+			if (meatmetal_effects(mtmp, geatme) == 2) return 2;
 			newsym(u.ux, u.uy);
 			break;
 		    } 
@@ -1983,7 +1983,7 @@ drain_life:
 		    if (geatme =
 		      ochain_has_material(level.objects[u.ux][u.uy], GOLD, 0)){
 			obj_extract_self(geatme);
-			Sprintf(buf, "from %s your %s",
+			Sprintf(buf, " from %s your %s",
 			  (Levitation)?"beneath":"between", makeplural(body_part(FOOT)));
 		    } else if ( geatme = ochain_has_material(invent, GOLD, 0)){
 #ifdef GOLDOBJ
@@ -2002,7 +2002,8 @@ drain_life:
 			    flags.botl = 1;
 			} else
 #endif
-			    obj_extract_self(geatme);
+				if(!evades_destruction(geatme))
+					obj_extract_self(geatme);
 		    }
 		    if (geatme){
 			if (!(mtmp->mcan || geatme->otyp == AMULET_OF_STRANGULATION ||
@@ -2014,7 +2015,7 @@ drain_life:
 			  Monnam(mtmp), (how)?"gobbles":"nabs", 
 			  yname(geatme), buf);
 			if (how) {
-			    if (meatmetal_effects(mtmp, geatme) == 3) return 2;
+			    if (meatmetal_effects(mtmp, geatme) == 2) return 2;
 			} else
 			    mpickobj(mtmp, geatme);
 			break;

--- a/src/mon.c
+++ b/src/mon.c
@@ -1088,6 +1088,10 @@ register struct obj * otmp;
 {
 	int poly, grow, heal, mstone;
 	struct permonst *ptr;
+
+	/* failsafe */
+	if (evades_destruction(otmp)) return 0;
+
 	if (mtmp->mhp < mtmp->mhpmax) {
 	    mtmp->mhp += objects[otmp->otyp].oc_weight;
 	    if (mtmp->mhp > mtmp->mhpmax) mtmp->mhp = mtmp->mhpmax;
@@ -1102,6 +1106,10 @@ register struct obj * otmp;
 	    grow = mlevelgain(otmp);
 	    heal = mhealup(otmp);
 	    mstone = mstoning(otmp);
+	    if (otmp->owornmask) {
+		remove_worn_item(otmp, FALSE);
+	    }
+	    obj_extract_self(otmp);
 	    delobj(otmp);
 	    ptr = mtmp->data;
 	    if (poly) {


### PR DESCRIPTION
This includes eating the candelabrum and phantom objects bugs reported
in the issues, as well as checking for the correct return status on
monsters dying whilst eating metal

I suspect there are other issues with this attack, and potentially with
this fix, but it seems okay from locally testing all the scenarios I
could think of

Fixes #85 