### PR TITLE
Fix lightsource creation for the artifact lightsources

### DIFF
--- a/src/artifact.c
+++ b/src/artifact.c
@@ -375,12 +375,6 @@ register boolean mod;
 		    register int m = a - artilist;
 		    otmp->oartifact = (mod ? m : 0);
 		    if (mod) {
-			/* Light up Candle of Eternal Flame and
-			 * Holy Spear of Light on creation.
-			 */
-			if (!artiexist[m] && artifact_light(otmp) &&
-			  otmp->oartifact != ART_SUNSWORD)
-			    begin_burn(otmp, FALSE);
 			otmp->quan = 1; /* guarantee only one of this artifact */
 #ifdef UNPOLYPILE	/* Artifacts are immune to unpolypile --ALI */
 			if (is_hazy(otmp)) {

--- a/src/pray.c
+++ b/src/pray.c
@@ -1867,6 +1867,11 @@ verbalize("In return for thy service, I grant thee the gift of Immortality!");
 		    dropy(otmp);
 		    at_your_feet("An object");
 		    godvoice(u.ualign.type, "Use my gift wisely!");
+		    /* Light up Candle of Eternal Flame and
+		     * Holy Spear of Light on creation.
+		     */
+		    if (artifact_light(otmp) && otmp->oartifact != ART_SUNSWORD)
+			begin_burn(otmp, FALSE);
 		    u.ugifts++;
 		    u.ublesscnt = rnz(300 + (50 * nartifacts));
 		    exercise(A_WIS, TRUE);

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -1088,6 +1088,12 @@ struct mkroom	*croom;
 
 	if (named)
 	    otmp = oname(otmp, o->name.str);
+	/* Light up Candle of Eternal Flame and
+	 * Holy Spear of Light on creation.
+	 */
+	if (artifact_light(otmp) && otmp->oartifact != ART_SUNSWORD) {
+		begin_burn(otmp, FALSE);
+	}
 
 	switch(o->containment) {
 	    static struct obj *container = 0;

--- a/src/zap.c
+++ b/src/zap.c
@@ -5283,6 +5283,11 @@ retry:
 					     Is_airlevel(&u.uz) || u.uinwater ?
 						   "slip" : "drop")),
 				       (const char *)0);
+			/* Light up Candle of Eternal Flame and
+			 * Holy Spear of Light on creation.
+			 */
+			if (artifact_light(otmp) && otmp->oartifact != ART_SUNSWORD)
+				begin_burn(otmp, FALSE);
 	    u.ublesscnt += rn1(100,50);  /* the gods take notice */
 	}
 }


### PR DESCRIPTION
If you received one as a sacrifice gift, begin_burn would fail to locate
the object.

This moves starting the eternal lightsources to after the object has
been placed, whether in inventory or on the ground. This covers the
cases where the object is received from sacrifice gifts, started out in
a special level (flame mage quest for example), or was wished for.

There could be other ways to get one of these artifact lightsources, but
I couldn't think of any offhand.

Fixes #90 
Fixes #89 